### PR TITLE
Temporarily remove Zipline from public pool

### DIFF
--- a/map-pools.yml
+++ b/map-pools.yml
@@ -185,7 +185,6 @@ pools:
     - "2014: Rage FFA"
     - Desert Country
     - Firestone Lake Research Facility
-    - Zipline
     - "Canyon: TDM"
     - Thornwood
     - Azure


### PR DESCRIPTION
Sparked from various discussions on Discord that this map in its current state is not playable, due to current shortfalls with Matrix. Until it's resolved, this map should be temporarily removed from the map pool until it's in a functional state.