### PR TITLE
Bastion Hill -> Bastion Hill CTF in mega, giga (duplicates removed)

### DIFF
--- a/map-pools.yml
+++ b/map-pools.yml
@@ -311,7 +311,7 @@ pools:
     - Masarin II
     - Wintery Cabin
     - Lights Out
-    - Bastion Hill
+    - Bastion Hill CTF
     - Hillside
     - Runes of Ruin
     - State of Decay
@@ -366,7 +366,6 @@ pools:
     - Broken Unity
     - Glacial Impact 2
     - Scorched Grove
-    - Bastion Hill
     - D-Day
     - Sugar Rush
     - Venice TDM


### PR DESCRIPTION
Currently both versions of Bastion Hill are in Giga and the original is also in Mega. Compared to the original, the CTF plays much better in my opinion and it makes sense to only have one of them in rotation.