### PR TITLE
Add Tree of Life to Nostalgia pool

### DIFF
--- a/map-pools.yml
+++ b/map-pools.yml
@@ -832,6 +832,7 @@ pools:
       - Medieval Warfare
       - Cake Wars
       - Sand Wars
+      - Tree of Life
       - Sky Traffic
       - Spaceship Battles
       - Airship Battle


### PR DESCRIPTION
This pull request adds Tree of Life to the Nostalgia pool, which was in the original iteration of Nostalgia in 2014. 