### PR TITLE
fix(touchdown): increase cycle time to 20s

### DIFF
--- a/map-pools.yml
+++ b/map-pools.yml
@@ -5,7 +5,7 @@ pools:
     enabled: true
     dynamic: true
     players: 1
-    cycle-time: "10s"
+    cycle-time: "20s"
     modifier: >-
       pow(
         score *


### PR DESCRIPTION
Increases the cycle time for the touchdown server pool to 20s as votebooks appear after 5s and the vote is shortened by 5s due to match preload, effectively making the voting time frame 0 seconds and thus making players unable to pick a map at all. 10 seconds should be a barebones time to react and pick a map and can be operatively bumped if needed.